### PR TITLE
fix internal datawidth in core_fifo

### DIFF
--- a/rtl/core/hci_core_fifo.sv
+++ b/rtl/core/hci_core_fifo.sv
@@ -40,8 +40,8 @@ module hci_core_fifo #(
 
   logic incoming_fifo_not_full;
 
-  logic        tcdm_master_r_valid_d, tcdm_master_r_valid_q;
-  logic [31:0] tcdm_master_r_data_d, tcdm_master_r_data_q;
+  logic          tcdm_master_r_valid_d, tcdm_master_r_valid_q;
+  logic [DW-1:0] tcdm_master_r_data_d, tcdm_master_r_data_q;
 
   hwpe_stream_intf_stream #(
     .DATA_WIDTH ( AW+DW+DW/BW+1 )


### PR DESCRIPTION
internal datawidth was fixed on 32bits -> FIFO pop gives out data of 32bits out of DW bits
fix: make the internal datawidth dependent on parameter DW